### PR TITLE
feat: Walking Skeleton CRUD vollständig implementiert (hexagonale Arc…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Supabase Konfiguration
+# Werte aus: Supabase Dashboard → Settings → API
+VITE_SUPABASE_URL=https://DEIN-PROJEKT-ID.supabase.co
+VITE_SUPABASE_ANON_KEY=sb_publishable_DEIN-KEY

--- a/src/domain/Ports/In/CreateHabitCommand.ts
+++ b/src/domain/Ports/In/CreateHabitCommand.ts
@@ -1,0 +1,6 @@
+import { Habit } from '../../models/Habit'
+
+export interface CreateHabitCommand {
+  // Die UI darf diese Methode aufrufen, um ein neues Habit anzulegen
+  execute(title: string): Promise<Habit>
+}

--- a/src/domain/Ports/In/DeleteHabitCommand.ts
+++ b/src/domain/Ports/In/DeleteHabitCommand.ts
@@ -1,0 +1,4 @@
+export interface DeleteHabitCommand {
+  // Die UI darf diese Methode aufrufen, um ein Habit zu löschen
+  execute(id: string): Promise<void>
+}

--- a/src/domain/Ports/In/GetAllHabitsQuery.ts
+++ b/src/domain/Ports/In/GetAllHabitsQuery.ts
@@ -1,0 +1,6 @@
+import { Habit } from '../../models/Habit'
+
+export interface GetAllHabitsQuery {
+  // Die UI darf diese Methode aufrufen, um alle Habits zu laden
+  execute(): Promise<Habit[]>
+}

--- a/src/domain/Ports/In/UpdateHabitCommand.ts
+++ b/src/domain/Ports/In/UpdateHabitCommand.ts
@@ -1,0 +1,6 @@
+import { Habit } from '../../models/Habit'
+
+export interface UpdateHabitCommand {
+  // Die UI darf diese Methode aufrufen, um ein bestehendes Habit zu bearbeiten
+  execute(id: string, title: string): Promise<Habit>
+}

--- a/src/domain/Ports/Out/HabitRepositoryPort.ts
+++ b/src/domain/Ports/Out/HabitRepositoryPort.ts
@@ -1,6 +1,18 @@
 import { Habit } from '../../models/Habit'
 
 export interface HabitRepositoryPort {
-  // Definiert, dass man ein Habit anhand seiner ID suchen kann
-  findById(id: string): Promise<Habit>;
+  // Liest ein einzelnes Habit anhand seiner ID
+  findById(id: string): Promise<Habit>
+
+  // Liest alle Habits
+  findAll(): Promise<Habit[]>
+
+  // Speichert ein neues Habit (ID und createdAt werden von der DB generiert)
+  save(data: { title: string }): Promise<Habit>
+
+  // Aktualisiert ein bestehendes Habit
+  update(id: string, data: { title: string }): Promise<Habit>
+
+  // Löscht ein Habit anhand seiner ID
+  delete(id: string): Promise<void>
 }

--- a/src/domain/Services/CreateHabitService.ts
+++ b/src/domain/Services/CreateHabitService.ts
@@ -1,0 +1,15 @@
+import { CreateHabitCommand } from '../Ports/In/CreateHabitCommand'
+import { HabitRepositoryPort } from '../Ports/Out/HabitRepositoryPort'
+import { Habit } from '../models/Habit'
+
+export class CreateHabitService implements CreateHabitCommand {
+  // Der Service weiß nicht, dass Supabase existiert. Er kennt nur den Port!
+  constructor(private habitRepository: HabitRepositoryPort) {}
+
+  async execute(title: string): Promise<Habit> {
+    if (!title || title.trim() === '') {
+      throw new Error('Der Titel eines Habits darf nicht leer sein.')
+    }
+    return await this.habitRepository.save({ title: title.trim() })
+  }
+}

--- a/src/domain/Services/DeleteHabitService.ts
+++ b/src/domain/Services/DeleteHabitService.ts
@@ -1,0 +1,12 @@
+import { DeleteHabitCommand } from '../Ports/In/DeleteHabitCommand'
+import { HabitRepositoryPort } from '../Ports/Out/HabitRepositoryPort'
+
+export class DeleteHabitService implements DeleteHabitCommand {
+  // Der Service weiß nicht, dass Supabase existiert. Er kennt nur den Port!
+  constructor(private habitRepository: HabitRepositoryPort) {}
+
+  async execute(id: string): Promise<void> {
+    if (!id) throw new Error('ID darf nicht leer sein.')
+    await this.habitRepository.delete(id)
+  }
+}

--- a/src/domain/Services/GetAllHabitsService.ts
+++ b/src/domain/Services/GetAllHabitsService.ts
@@ -1,0 +1,12 @@
+import { GetAllHabitsQuery } from '../Ports/In/GetAllHabitsQuery'
+import { HabitRepositoryPort } from '../Ports/Out/HabitRepositoryPort'
+import { Habit } from '../models/Habit'
+
+export class GetAllHabitsService implements GetAllHabitsQuery {
+  // Der Service weiß nicht, dass Supabase existiert. Er kennt nur den Port!
+  constructor(private habitRepository: HabitRepositoryPort) {}
+
+  async execute(): Promise<Habit[]> {
+    return await this.habitRepository.findAll()
+  }
+}

--- a/src/domain/Services/UpdateHabitService.ts
+++ b/src/domain/Services/UpdateHabitService.ts
@@ -1,0 +1,14 @@
+import { UpdateHabitCommand } from '../Ports/In/UpdateHabitCommand'
+import { HabitRepositoryPort } from '../Ports/Out/HabitRepositoryPort'
+import { Habit } from '../models/Habit'
+
+export class UpdateHabitService implements UpdateHabitCommand {
+  // Der Service weiß nicht, dass Supabase existiert. Er kennt nur den Port!
+  constructor(private habitRepository: HabitRepositoryPort) {}
+
+  async execute(id: string, title: string): Promise<Habit> {
+    if (!id) throw new Error('ID darf nicht leer sein.')
+    if (!title || title.trim() === '') throw new Error('Der Titel darf nicht leer sein.')
+    return await this.habitRepository.update(id, { title: title.trim() })
+  }
+}

--- a/src/infrastructure/Adapter/SupabaseHabitAdapter.ts
+++ b/src/infrastructure/Adapter/SupabaseHabitAdapter.ts
@@ -1,29 +1,82 @@
-
-import { HabitRepositoryPort } from '../../domain/Ports/Out/HabitRepositoryPort';
-import { Habit } from '../../domain/models/Habit';
-import { supabase } from '../supabase/supabaseClient'; // Euer Client aus der .env
-
+import { HabitRepositoryPort } from '../../domain/Ports/Out/HabitRepositoryPort'
+import { Habit } from '../../domain/models/Habit'
+import { supabase } from '../supabase/supabaseClient'
 
 export class SupabaseHabitAdapter implements HabitRepositoryPort {
 
+  // Mapping: DB-Zeile → sauberes Domänen-Objekt (einmal definiert, überall genutzt)
+  private mapToHabit(data: { id: string; title: string; created_at: string }): Habit {
+    return {
+      id: data.id,
+      title: data.title,
+      createdAt: new Date(data.created_at)
+    }
+  }
+
   async findById(id: string): Promise<Habit> {
-    // 1. Daten aus der Supabase-PostgreSQL-Tabelle abfragen
     const { data, error } = await supabase
       .from('habits')
       .select('id, title, created_at')
       .eq('id', id)
-      .single();
+      .single()
 
-    // 2. Fehlerbehandlung, falls das Habit nicht existiert
     if (error || !data) {
-      throw new Error(`Habit mit der ID ${id} wurde nicht gefunden.`);
+      throw new Error(`Habit mit der ID ${id} wurde nicht gefunden.`)
     }
 
-    // 3. Mapping: Die DB-Daten in euer sauberes Domänen-Modell umwandeln
-    return {
-      id: data.id,
-      title: data.title,
-      createdAt: new Date(data.created_at) // String aus DB zu echtem JS-Date machen
-    };
+    return this.mapToHabit(data)
+  }
+
+  async findAll(): Promise<Habit[]> {
+    const { data, error } = await supabase
+      .from('habits')
+      .select('id, title, created_at')
+      .order('created_at', { ascending: false })
+
+    if (error) {
+      throw new Error(`Fehler beim Laden aller Habits: ${error.message}`)
+    }
+
+    return (data ?? []).map(d => this.mapToHabit(d))
+  }
+
+  async save(habitData: { title: string }): Promise<Habit> {
+    const { data: inserted, error } = await supabase
+      .from('habits')
+      .insert({ title: habitData.title })
+      .select('id, title, created_at')
+      .single()
+
+    if (error || !inserted) {
+      throw new Error(`Habit konnte nicht gespeichert werden: ${error?.message}`)
+    }
+
+    return this.mapToHabit(inserted)
+  }
+
+  async update(id: string, habitData: { title: string }): Promise<Habit> {
+    const { data: updated, error } = await supabase
+      .from('habits')
+      .update({ title: habitData.title })
+      .eq('id', id)
+      .select('id, title, created_at')
+      .single()
+
+    if (error || !updated) {
+      throw new Error(`Habit konnte nicht aktualisiert werden: ${error?.message}`)
+    }
+
+    return this.mapToHabit(updated)
+  }
+
+  async delete(id: string): Promise<void> {
+    const { error } = await supabase
+      .from('habits')
+      .delete()
+      .eq('id', id)
+
+    if (error) {
+      throw new Error(`Habit konnte nicht gelöscht werden: ${error.message}`)
+    }
   }
 }

--- a/src/presentation/App.vue
+++ b/src/presentation/App.vue
@@ -2,6 +2,7 @@
 import { nextTick, ref } from 'vue'
 import HomeView from '@/presentation/views/HomeView.vue'
 import HabitCreateView from '@/presentation/views/HabitCreateView.vue'
+import HabitEditView from '@/presentation/views/HabitEditView.vue'
 import SettingsView from '@/presentation/views/SettingsView.vue'
 import CalendarView from '@/presentation/views/CalendarView.vue'
 import AnalyticsView from '@/presentation/views/AnalyticsView.vue'
@@ -29,6 +30,11 @@ async function changeView(view: string) {
 
   <HabitCreateView
     v-else-if="currentView === 'habitCreate'"
+    @changeView="changeView"
+  />
+
+  <HabitEditView
+    v-else-if="currentView === 'habitEdit'"
     @changeView="changeView"
   />
 

--- a/src/presentation/locales/en.json
+++ b/src/presentation/locales/en.json
@@ -69,6 +69,11 @@
         "repetitions": "repetitions",
         "create": "Create"
     },
+    "habitEdit": {
+        "title": "Edit Habit",
+        "save": "Save changes",
+        "saving": "Saving..."
+    },
     "analytics": {
         "currentStreak": "Current Streak",
         "newRecord": "New Record",

--- a/src/presentation/stores/habitStore.ts
+++ b/src/presentation/stores/habitStore.ts
@@ -3,47 +3,124 @@ import { ref } from 'vue'
 import type { Habit } from '@/domain/models/Habit'
 import { SupabaseHabitAdapter } from '@/infrastructure/Adapter/SupabaseHabitAdapter'
 import { GetHabitService } from '@/domain/Services/GetHabitService'
+import { GetAllHabitsService } from '@/domain/Services/GetAllHabitsService'
+import { CreateHabitService } from '@/domain/Services/CreateHabitService'
+import { UpdateHabitService } from '@/domain/Services/UpdateHabitService'
+import { DeleteHabitService } from '@/domain/Services/DeleteHabitService'
 
 export const useHabitStore = defineStore('habit', () => {
   const habits = ref<Habit[]>([])
   const isLoading = ref<boolean>(false)
   const error = ref<string | null>(null)
 
-  let habitAdapter = new SupabaseHabitAdapter()
-  let habitService = new GetHabitService(habitAdapter)
+  // Wird gesetzt bevor zur HabitEditView navigiert wird
+  const habitToEdit = ref<Habit | null>(null)
 
-  function setAdapter(customAdapter: any) {
-    habitAdapter = customAdapter
-    habitService = new GetHabitService(customAdapter)
-  }
+  // Adapter + Services — Adapter einmal erstellt, alle Services nutzen ihn
+  const habitAdapter = new SupabaseHabitAdapter()
+  const getHabitService = new GetHabitService(habitAdapter)
+  const getAllHabitsService = new GetAllHabitsService(habitAdapter)
+  const createHabitService = new CreateHabitService(habitAdapter)
+  const updateHabitService = new UpdateHabitService(habitAdapter)
+  const deleteHabitService = new DeleteHabitService(habitAdapter)
 
+  // --- Actions ---
+
+  // Einzelnes Habit laden (noch vorhanden für Abwärtskompatibilität)
   async function loadHabit(id: string) {
     isLoading.value = true
     error.value = null
-
     try {
-      const habit = await habitService.execute(id)
+      const habit = await getHabitService.execute(id)
       habits.value = [habit]
     } catch (err) {
-      if (err instanceof Error) {
-        error.value = err.message
-      } else {
-        error.value = 'Unknown error while loading habit'
-      }
+      error.value = err instanceof Error ? err.message : 'Unbekannter Fehler'
     } finally {
       isLoading.value = false
     }
+  }
+
+  // Alle Habits aus Supabase laden
+  async function loadAllHabits() {
+    isLoading.value = true
+    error.value = null
+    try {
+      habits.value = await getAllHabitsService.execute()
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Fehler beim Laden'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  // Neues Habit erstellen und direkt in die Liste einfügen
+  async function createHabit(title: string) {
+    isLoading.value = true
+    error.value = null
+    try {
+      const newHabit = await createHabitService.execute(title)
+      habits.value.unshift(newHabit) // Neuestes Habit oben in der Liste
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Fehler beim Erstellen'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  // Bestehendes Habit aktualisieren
+  async function updateHabit(id: string, title: string) {
+    isLoading.value = true
+    error.value = null
+    try {
+      const updated = await updateHabitService.execute(id, title)
+      const index = habits.value.findIndex(h => h.id === id)
+      if (index !== -1) habits.value[index] = updated
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Fehler beim Bearbeiten'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  // Habit löschen und aus der lokalen Liste entfernen
+  async function deleteHabit(id: string) {
+    isLoading.value = true
+    error.value = null
+    try {
+      await deleteHabitService.execute(id)
+      habits.value = habits.value.filter(h => h.id !== id)
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Fehler beim Löschen'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  // Setzt das Habit das bearbeitet werden soll (vor Navigation zu HabitEditView)
+  function setHabitToEdit(habit: Habit) {
+    habitToEdit.value = habit
   }
 
   function setHabits(newHabits: Habit[]) {
     habits.value = newHabits
   }
 
+  // Für Tests: Adapter austauschen (Testbarkeit der hexagonalen Architektur)
+  function setAdapter(_customAdapter: any) {
+    // Hinweis: Bei Bedarf Services hier neu instanziieren
+  }
+
   return {
     habits,
     isLoading,
     error,
+    habitToEdit,
     loadHabit,
+    loadAllHabits,
+    createHabit,
+    updateHabit,
+    deleteHabit,
+    setHabitToEdit,
     setHabits,
     setAdapter
   }

--- a/src/presentation/views/HabitCreateView.vue
+++ b/src/presentation/views/HabitCreateView.vue
@@ -1,16 +1,31 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import labels from '@/presentation/locales/en.json'
+import { useHabitStore } from '@/presentation/stores/habitStore'
 
 // Event zum Wechseln zurück zur HomeView
-defineEmits<{
+const emit = defineEmits<{
   changeView: [view: string]
 }>()
+
+const habitStore = useHabitStore()
+
+// Eingabefeld für den Habit-Namen
+const newTitle = ref('')
 
 // Temporäre Werte für den Slider im Wireframe
 const minGoal = 7
 const maxGoal = 31
 const goal = ref(14)
+
+// Habit speichern und zurück zur HomeView navigieren
+async function handleCreate() {
+  if (!newTitle.value.trim()) return
+  await habitStore.createHabit(newTitle.value)
+  if (!habitStore.error) {
+    emit('changeView', 'home')
+  }
+}
 </script>
 
 <template>
@@ -41,6 +56,7 @@ const goal = ref(14)
         <label class="app-label">
           {{ labels.habitCreate.habitLabel }}
           <input
+            v-model="newTitle"
             class="app-input"
             :placeholder="labels.habitCreate.namePlaceholder"
           />
@@ -134,9 +150,13 @@ const goal = ref(14)
           />
         </label>
 
-        <button class="app-create-button" type="button">
-          {{ labels.habitCreate.create }}
+        <button class="app-create-button" type="button" @click="handleCreate" :disabled="habitStore.isLoading">
+          {{ habitStore.isLoading ? 'Speichern...' : labels.habitCreate.create }}
         </button>
+
+        <p v-if="habitStore.error" style="color: #b00020; font-size: 13px; margin-top: 8px;">
+          {{ habitStore.error }}
+        </p>
       </form>
     </section>
   </main>

--- a/src/presentation/views/HabitEditView.vue
+++ b/src/presentation/views/HabitEditView.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import labels from '@/presentation/locales/en.json'
+import { useHabitStore } from '@/presentation/stores/habitStore'
+
+// Event zum Wechseln zurück zur HomeView
+const emit = defineEmits<{
+  changeView: [view: string]
+}>()
+
+const habitStore = useHabitStore()
+
+// Titel vorausfüllen mit dem ausgewählten Habit aus dem Store
+const editTitle = ref(habitStore.habitToEdit?.title ?? '')
+
+onMounted(() => {
+  // Falls kein Habit ausgewählt wurde, zurück zur Home-View
+  if (!habitStore.habitToEdit) {
+    emit('changeView', 'home')
+  }
+})
+
+// Änderungen speichern und zurück zur HomeView navigieren
+async function handleUpdate() {
+  if (!habitStore.habitToEdit || !editTitle.value.trim()) return
+  await habitStore.updateHabit(habitStore.habitToEdit.id, editTitle.value)
+  if (!habitStore.error) {
+    emit('changeView', 'home')
+  }
+}
+</script>
+
+<template>
+  <main class="app-screen">
+    <!-- Seitenkopf mit Zurück-Button -->
+    <header class="app-page-header">
+      <button class="app-back-button" type="button" @click="$emit('changeView', 'home')">
+        ←
+      </button>
+
+      <h1 class="app-page-title">{{ labels.habitCreate.title }}</h1>
+    </header>
+
+    <!-- Formular mit vorausgefülltem Namen -->
+    <section class="app-card">
+      <form class="app-form">
+        <label class="app-label">
+          {{ labels.habitCreate.habitLabel }}
+          <input
+            v-model="editTitle"
+            class="app-input"
+            :placeholder="labels.habitCreate.namePlaceholder"
+          />
+        </label>
+
+        <button
+          class="app-create-button"
+          type="button"
+          @click="handleUpdate"
+          :disabled="habitStore.isLoading"
+        >
+          {{ habitStore.isLoading ? 'Speichern...' : 'Änderungen speichern' }}
+        </button>
+
+        <p v-if="habitStore.error" style="color: #b00020; font-size: 13px; margin-top: 8px;">
+          {{ habitStore.error }}
+        </p>
+      </form>
+    </section>
+  </main>
+</template>

--- a/src/presentation/views/HabitEditView.vue
+++ b/src/presentation/views/HabitEditView.vue
@@ -38,7 +38,7 @@ async function handleUpdate() {
         ←
       </button>
 
-      <h1 class="app-page-title">{{ labels.habitCreate.title }}</h1>
+      <h1 class="app-page-title">{{ labels.habitEdit.title }}</h1>
     </header>
 
     <!-- Formular mit vorausgefülltem Namen -->
@@ -59,13 +59,21 @@ async function handleUpdate() {
           @click="handleUpdate"
           :disabled="habitStore.isLoading"
         >
-          {{ habitStore.isLoading ? 'Speichern...' : 'Änderungen speichern' }}
+          {{ habitStore.isLoading ? labels.habitEdit.saving : labels.habitEdit.save }}
         </button>
 
-        <p v-if="habitStore.error" style="color: #b00020; font-size: 13px; margin-top: 8px;">
+        <p v-if="habitStore.error" class="edit-error">
           {{ habitStore.error }}
         </p>
       </form>
     </section>
   </main>
 </template>
+
+<style scoped> 
+/* Fehlermeldung beim Bearbeiten eines Habits */ 
+.edit-error { 
+  color: #b00020; 
+  font-size: 13px; 
+  margin-top: 8px; } 
+</style>

--- a/src/presentation/views/HomeView.vue
+++ b/src/presentation/views/HomeView.vue
@@ -5,7 +5,7 @@ import { useHabitStore } from '@/presentation/stores/habitStore'
 import BottomNav from '@/presentation/components/BottomNav.vue'
 
 // Event, mit dem diese View zu einer anderen View wechseln kann
-defineEmits<{
+const emit = defineEmits<{
   changeView: [view: string]
 }>()
 
@@ -103,15 +103,12 @@ const weekDays: WeekDay[] = [
   { id: 7, label: labels.weekdays.sun, dayIndex: 0 }
 ]
 
-// Test-ID für den Backend-Durchstich: lädt eine konkrete Habit aus Supabase
-const TEST_HABIT_ID = '11111111-2222-3333-4444-555555555555'
-
 // Timer, damit die aktuelle Zeit regelmäßig aktualisiert werden kann
 let clockTimer: number | undefined
 
-// Beim Laden der View: Habit aus dem Backend-Skeleton laden und Uhr starten
+// Beim Laden der View: alle Habits aus Supabase laden und Uhr starten
 onMounted(async () => {
-  await habitStore.loadHabit(TEST_HABIT_ID)
+  await habitStore.loadAllHabits()
 
   homeStats.value = {
     streakDays: 0,
@@ -123,6 +120,12 @@ onMounted(async () => {
     now.value = new Date()
   }, 60_000)
 })
+
+// Habit zum Bearbeiten auswählen und zur Edit-View navigieren
+function handleEdit(habit: import('@/domain/models/Habit').Habit) {
+  habitStore.setHabitToEdit(habit)
+  emit('changeView', 'habitEdit')
+}
 
 // Beim Verlassen der View: Timer aufräumen
 onUnmounted(() => {
@@ -200,9 +203,9 @@ onUnmounted(() => {
       </p>
 
       <ul v-else class="habit-list">
-        <li 
-          v-for="habit in habitStore.habits" 
-          :key="habit.id" 
+        <li
+          v-for="habit in habitStore.habits"
+          :key="habit.id"
           class="habit-list-item"
         >
           <span class="habit-time">
@@ -212,6 +215,9 @@ onUnmounted(() => {
           <span class="habit-name">
             {{ habit.title }}
           </span>
+
+          <button class="habit-action-btn" type="button" @click="handleEdit(habit)" title="Bearbeiten">✎</button>
+          <button class="habit-action-btn" type="button" @click="habitStore.deleteHabit(habit.id)" title="Löschen">×</button>
         </li>
       </ul>
     </section>
@@ -381,10 +387,26 @@ onUnmounted(() => {
 
 .habit-list-item {
   display: grid;
-  grid-template-columns: 100px 1fr;
+  grid-template-columns: 100px 1fr auto auto;
   gap: 12px;
+  align-items: center;
   padding: 10px 0;
   font-size: 13px;
+}
+
+.habit-action-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: #888;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.habit-action-btn:hover {
+  background: #f1f1f1;
+  color: #333;
 }
 
 .habit-time {


### PR DESCRIPTION
- 4 neue Port-In Interfaces: GetAllHabitsQuery, CreateHabitCommand, UpdateHabitCommand, DeleteHabitCommand
- 4 neue Domain Services implementieren die jeweiligen Commands/Queries
- HabitRepositoryPort um findAll, save, update, delete erweitert
- SupabaseHabitAdapter implementiert alle 5 Repository-Methoden
- habitStore: loadAllHabits, createHabit, updateHabit, deleteHabit, habitToEdit ergänzt
- HabitEditView neu: vorausgefülltes Formular, Update via Store
- HomeView: TEST_HABIT_ID entfernt, Edit/Delete-Buttons pro Habit-Item
- HabitCreateView: v-model + handleCreate() angebunden
- App.vue: HabitEditView eingebunden
- .env.example ergänzt