### PR TITLE
[Frontend] BottomNav aktiver Tab (#53) + Habit-Checkbox in HomeView (#54)

### DIFF
--- a/src/presentation/App.vue
+++ b/src/presentation/App.vue
@@ -25,6 +25,7 @@ async function changeView(view: string) {
 <template>
   <HomeView
     v-if="currentView === 'home'"
+    :current-view="currentView"
     @changeView="changeView"
   />
 
@@ -40,16 +41,19 @@ async function changeView(view: string) {
 
   <SettingsView
     v-else-if="currentView === 'settings'"
+    :current-view="currentView"
     @changeView="changeView"
   />
 
   <CalendarView
     v-else-if="currentView === 'calendar'"
+    :current-view="currentView"
     @changeView="changeView"
   />
 
   <AnalyticsView
     v-else-if="currentView === 'analytics'"
+    :current-view="currentView"
     @changeView="changeView"
   />
 </template>

--- a/src/presentation/components/BottomNav.vue
+++ b/src/presentation/components/BottomNav.vue
@@ -2,6 +2,11 @@
 // Zentrale UI-Texte für die Navigationslabels
 import labels from '@/presentation/locales/en.json'
 
+// Aktuell aktive View, um den passenden Tab hervorzuheben
+defineProps<{
+  currentView: string
+}>()
+
 // Event zum Wechseln zwischen den Views
 defineEmits<{
   changeView: [view: string]
@@ -11,17 +16,28 @@ defineEmits<{
 <template>
   <!-- Wiederverwendbare untere Navigation für die wichtigsten App-Bereiche -->
   <nav class="bottom-nav">
-    <button type="button" @click="$emit('changeView', 'analytics')">
+    <button
+      type="button"
+      :class="{ active: currentView === 'analytics' }"
+      @click="$emit('changeView', 'analytics')"
+    >
       <span class="nav-icon">⌁</span>
       <span>{{ labels.navigation.analytics }}</span>
     </button>
 
-    <button type="button" @click="$emit('changeView', 'home')">
+    <button
+      type="button"
+      :class="{ active: currentView === 'home' }"
+      @click="$emit('changeView', 'home')"
+    >
       <span class="nav-icon">⌂</span>
       <span>{{ labels.navigation.home }}</span>
     </button>
 
-    <button type="button">
+    <button
+      type="button"
+      :class="{ active: currentView === 'social' }"
+    >
       <span class="nav-icon">◎</span>
       <span>{{ labels.navigation.social }}</span>
     </button>
@@ -54,6 +70,16 @@ defineEmits<{
     flex-direction: column;
     align-items: center;
     gap: 4px;
+    cursor: pointer;
+}
+
+/* Hervorhebung des aktuell aktiven Tabs */
+.bottom-nav button.active {
+    color: #7437d8;
+}
+
+.bottom-nav button.active .nav-icon {
+    transform: scale(1.15);
 }
 
 .nav-icon {

--- a/src/presentation/views/AnalyticsView.vue
+++ b/src/presentation/views/AnalyticsView.vue
@@ -2,6 +2,11 @@
 import labels from '@/presentation/locales/en.json'
 import BottomNav from '@/presentation/components/BottomNav.vue'
 
+// Aktuell aktive View, um den passenden Tab in der Navigation hervorzuheben
+defineProps<{
+  currentView: string
+}>()
+
 // Event zum Wechseln zwischen Views
 defineEmits<{
   changeView: [view: string]
@@ -77,7 +82,7 @@ const heatmapDays = 56
     </section>
 
     <!-- Untere Navigation -->
-    <BottomNav @changeView="$emit('changeView', $event)" />
+    <BottomNav :current-view="currentView" @changeView="$emit('changeView', $event)" />
   </main>
 </template>
 

--- a/src/presentation/views/CalendarView.vue
+++ b/src/presentation/views/CalendarView.vue
@@ -3,6 +3,11 @@ import { computed, ref } from 'vue'
 import labels from '@/presentation/locales/en.json'
 import BottomNav from '@/presentation/components/BottomNav.vue'
 
+// Aktuell aktive View, um den passenden Tab in der Navigation hervorzuheben
+defineProps<{
+  currentView: string
+}>()
+
 // Event zum Wechseln zwischen Views
 defineEmits<{
   changeView: [view: string]
@@ -161,7 +166,7 @@ function goToNextMonth() {
     </section>
 
     <!-- Untere Navigation -->
-    <BottomNav @changeView="$emit('changeView', $event)" />
+    <BottomNav :current-view="currentView" @changeView="$emit('changeView', $event)" />
   </main>
 </template>
 

--- a/src/presentation/views/HomeView.vue
+++ b/src/presentation/views/HomeView.vue
@@ -4,6 +4,11 @@ import labels from '@/presentation/locales/en.json'
 import { useHabitStore } from '@/presentation/stores/habitStore'
 import BottomNav from '@/presentation/components/BottomNav.vue'
 
+// Aktuell aktive View, um den passenden Tab in der Navigation hervorzuheben
+defineProps<{
+  currentView: string
+}>()
+
 // Event, mit dem diese View zu einer anderen View wechseln kann
 const emit = defineEmits<{
   changeView: [view: string]
@@ -31,6 +36,27 @@ type HomeStats = {
 
 // Store: enthält Habits, Loading-State und Error-State
 const habitStore = useHabitStore()
+
+// IDs der heute bereits abgehakten Habits (nur lokaler Zustand, kein Backend)
+const completedHabitIds = ref<Set<string>>(new Set())
+
+// Prüft, ob ein Habit für heute als erledigt markiert ist
+function isHabitDone(id: string): boolean {
+  return completedHabitIds.value.has(id)
+}
+
+// Habit als erledigt/nicht erledigt umschalten
+function toggleHabitDone(id: string) {
+  const updated = new Set(completedHabitIds.value)
+
+  if (updated.has(id)) {
+    updated.delete(id)
+  } else {
+    updated.add(id)
+  }
+
+  completedHabitIds.value = updated
+}
 
 // Temporäre Statistikwerte für den oberen Statistikblock
 const homeStats = ref<HomeStats>({
@@ -207,6 +233,7 @@ onUnmounted(() => {
           v-for="habit in habitStore.habits"
           :key="habit.id"
           class="habit-list-item"
+          :class="{ done: isHabitDone(habit.id) }"
         >
           <span class="habit-time">
             {{ habit.createdAt.toLocaleDateString('de-DE') }}
@@ -218,6 +245,14 @@ onUnmounted(() => {
 
           <button class="habit-action-btn" type="button" @click="handleEdit(habit)" title="Bearbeiten">✎</button>
           <button class="habit-action-btn" type="button" @click="habitStore.deleteHabit(habit.id)" title="Löschen">×</button>
+
+          <input
+            type="checkbox"
+            class="habit-checkbox"
+            :checked="isHabitDone(habit.id)"
+            :aria-label="habit.title"
+            @change="toggleHabitDone(habit.id)"
+          />
         </li>
       </ul>
     </section>
@@ -254,7 +289,7 @@ onUnmounted(() => {
     </section>
 
     <!-- Wiederverwendbare untere Navigation -->
-    <BottomNav @changeView="$emit('changeView', $event)" />
+    <BottomNav :current-view="currentView" @changeView="$emit('changeView', $event)" />
   </main>
 </template>
 
@@ -387,7 +422,7 @@ onUnmounted(() => {
 
 .habit-list-item {
   display: grid;
-  grid-template-columns: 100px 1fr auto auto;
+  grid-template-columns: 100px 1fr auto auto auto;
   gap: 12px;
   align-items: center;
   padding: 10px 0;
@@ -415,6 +450,21 @@ onUnmounted(() => {
 
 .habit-name {
   color: #1f1f1f;
+}
+
+/* Checkbox zum Abhaken eines Habits */
+.habit-checkbox {
+  width: 20px;
+  height: 20px;
+  accent-color: #7437d8;
+  cursor: pointer;
+}
+
+/* Visuelles Feedback für erledigte Habits */
+.habit-list-item.done .habit-time,
+.habit-list-item.done .habit-name {
+  color: #aaaaaa;
+  text-decoration: line-through;
 }
 
 .habit-status,

--- a/src/presentation/views/SettingsView.vue
+++ b/src/presentation/views/SettingsView.vue
@@ -2,6 +2,11 @@
 import labels from '@/presentation/locales/en.json'
 import BottomNav from '@/presentation/components/BottomNav.vue'
 
+// Aktuell aktive View, um den passenden Tab in der Navigation hervorzuheben
+defineProps<{
+  currentView: string
+}>()
+
 // Event zum Wechseln zwischen Views
 defineEmits<{
   changeView: [view: string]
@@ -39,7 +44,7 @@ defineEmits<{
     </section>
 
      <!-- Untere Navigation -->
-    <BottomNav @changeView="$emit('changeView', $event)" />
+    <BottomNav :current-view="currentView" @changeView="$emit('changeView', $event)" />
   </main>
 </template>
 


### PR DESCRIPTION
﻿## Was
Setzt zwei Frontend-Issues um, die noch nicht in main waren:

- **#53** BottomNav hebt den aktiven Tab hervor
- **#54** Habits in der HomeView koennen als erledigt abgehakt werden

## Details
**#53 – Aktiver Tab**
- `currentView` wird von `App.vue` an die Views mit BottomNav (Home, Settings, Calendar, Analytics) durchgereicht
- Aktiver Tab erhaelt Akzentfarbe (#7437d8) + leicht vergroessertes Icon

**#54 – Habit-Checkbox**
- Checkbox pro Habit-Item in der HomeView (lokaler reaktiver State, kein Backend noetig)
- Erledigte Habits werden ausgegraut und durchgestrichen

## Wichtig fuer den Review
- Branch sitzt auf dem **aktuellen main** (nach CRUD-Merge #62)
- Die bestehenden **Edit-/Delete-Buttons** der Habit-Liste bleiben voll erhalten (Checkbox wurde zusaetzlich eingefuegt)
- Nur additive Aenderungen, `vite build` laeuft fehlerfrei durch (98 Module)

Closes #53
Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
