### PR TITLE
[Frontend] Social-Button aus BottomNav entfernen

### DIFF
--- a/src/presentation/components/BottomNav.vue
+++ b/src/presentation/components/BottomNav.vue
@@ -33,14 +33,6 @@ defineEmits<{
       <span class="nav-icon">⌂</span>
       <span>{{ labels.navigation.home }}</span>
     </button>
-
-    <button
-      type="button"
-      :class="{ active: currentView === 'social' }"
-    >
-      <span class="nav-icon">◎</span>
-      <span>{{ labels.navigation.social }}</span>
-    </button>
   </nav>
 </template>
 


### PR DESCRIPTION
﻿Entfernt den nicht funktionalen Social-Eintrag aus der unteren Navigation, da die Social-Funktion vorerst nicht weiter ausgebaut wird. Es bleiben Analytics und Home. vite build laeuft fehlerfrei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
